### PR TITLE
docs: remove duplicated space

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
       with:
         # Disabling shallow clone is recommended for improving relevancy of reporting
         fetch-depth: 0
-    - name:  Install sonar-scanner and build-wrapper
+    - name: Install sonar-scanner and build-wrapper
       uses: sonarsource/sonarcloud-github-c-cpp@v1
     - name: Run build-wrapper
       run: |


### PR DESCRIPTION
This PR removes an extra space in the [README.md](https://github.com/SonarSource/sonarcloud-github-c-cpp/blob/8d08b4c506dc7a0601ad08b06f73fc9718cea84e/README.md?plain=1#L54). Besides obvious esthetics also `yamllint` complains about this part, when it is simply copied and pasted into some workflow file.

Please correct me if I am wrong, but I think that the [PR template](https://github.com/SonarSource/sonarcloud-github-c-cpp/blob/8d08b4c506dc7a0601ad08b06f73fc9718cea84e/.github/PULL_REQUEST_TEMPLATE.md) is not really applicable here.