### PR TITLE
update actions/cache to v4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Cache sonar-scanner installation
       id: cache-sonar-tools
       if: inputs.cache-binaries == 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         # The default value is 60mins. Reaching timeout is treated the same as a cache miss.
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1


### PR DESCRIPTION
This updates the cache action to v4 (which only has [minimal changes](https://github.com/actions/cache?tab=readme-ov-file#v4)), thus silencing a warning about v3 still using the deprecated Node.js 16 (see [here](https://github.com/ogdf/ogdf/actions/runs/7708388057?pr=231) for an example) for all runs that use this action:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

---

### Reviewer checklist

* [ ] Code review
* [ ] Functional validation
* [ ] Check commits are clean