### PR TITLE
SCCPPGHA-21 Change title back to SonarCloud Scan for C and C++

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'SonarQube Cloud Scan for C and C++'
+name: 'SonarCloud Scan for C and C++'
 description: >
   Scan your C and C++ code with SonarQube Cloud. (Formerly SonarCloud)
 branding:


### PR DESCRIPTION
[SCCPPGHA-21](https://sonarsource.atlassian.net/browse/SCCPPGHA-21)

**Kept in draft to avoid accidental merging - should be merged just before release**

Same context as https://github.com/SonarSource/sonarqube-scan-action/pull/166

Unlike `sonarqube-scan-action`, no bug-fix release needed specifically for this change, since:
- the change of name has not been released yet, so there has not been a change of URL in the marketplace (which only happens on release from `main`)
  - the current URL in the Marketplace is still: https://github.com/marketplace/actions/sonarcloud-scan-for-c-and-c 
- this action has been deprecated, and removed from documentation and tutorials already (although it may still appear on the website and in promotional materials about GHAs)

[SCCPPGHA-21]: https://sonarsource.atlassian.net/browse/SCCPPGHA-21?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ