### PR TITLE
SCCPPGHA-16 Deprecate in favor of sonarqube-scan-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # Scan your C, C++, and Objective-C code with SonarQube Cloud [![QA](https://github.com/SonarSource/sonarcloud-github-c-cpp/actions/workflows/qa.yml/badge.svg)](https://github.com/SonarSource/sonarcloud-github-c-cpp/actions/workflows/qa.yml)
 
+> [!WARNING]
+> This action is deprecated and will be removed in a future release.
+>
+> Please use the `sonarqube-scan-action` and its `install-build-wrapper` sub-action instead.
+>
+> More specifically, if the action is used to install both the SonarScanner CLI and the Build Wrapper:
+> - replace `sonarcloud-github-c-cpp` with the latest version of `SonarSource/sonarqube-scan-action/install-build-wrapper`
+> - if the step calling the action is named `Install sonar-scanner and build-wrapper`, or something similar, rename it to `Install Build Wrapper`
+> - replace the step calling `sonar-scanner` with a step using `SonarSource/sonarqube-scan-action`
+> - the arguments passed to `sonar-scanner` should be passed to the action via the `args` input parameter
+>
+> If the action is used to install the SonarScanner CLI, and the Build Wrapper is not required:
+> - remove the `sonarcloud-github-c-cpp` step altogether
+> - replace the step calling `sonar-scanner` with a step using `SonarSource/sonarqube-scan-action`
+> - the arguments passed to `sonar-scanner` should be passed to the action via the `args` input parameter
+>
+> Check the C++ section in [the README of the `sonarqube-scan-action`](https://github.com/SonarSource/sonarqube-scan-action/?tab=readme-ov-file#cloud-1) for complete examples.
+
 This SonarSource project, available as a GitHub Action, scans your C, C++, and Objective-C projects with SonarQube [Cloud](https://www.sonarsource.com/products/sonarcloud/).
 
 ![Logo](./images/SQ_Logo_Cloud_Dark_Backgrounds.png#gh-dark-mode-only)

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Deprecation warning
+      shell: bash
+      run: |
+        echo "::warning title=SonarScanner::This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action and its install-build-wrapper sub-action instead."
     - name: SonarQube Cloud Scan
       id: scan
       uses: sonarsource/sonarqube-github-c-cpp@25a2efe466506d2293f19f2e3062df4247477464


### PR DESCRIPTION
[SCCPPGHA-16](https://sonarsource.atlassian.net/browse/SCCPPGHA-16)

**Kept in draft to avoid accidental merging - should be merged just before release**

Same as https://github.com/SonarSource/sonarqube-github-c-cpp/pull/23, but for the SQC action.

Deprecation log (example [here](https://github.com/SonarSource/sonarcloud-github-c-cpp/actions/runs/12483927273/job/34840535015?pr=66#step:4:15)):
![image](https://github.com/user-attachments/assets/43affd61-b1f8-4136-9922-abc9904e0568)

Deprecation annotation (example [here](https://github.com/SonarSource/sonarcloud-github-c-cpp/actions/runs/12483927273/job/34840535015?pr=66)):
![image](https://github.com/user-attachments/assets/2e70068f-c43d-4850-8717-fdd7f470b85c)

Deprecation notice in README (updated version [here](https://github.com/SonarSource/sonarcloud-github-c-cpp/blob/antonio/SCCPPGHA-16-deprecate/README.md)):
![image](https://github.com/user-attachments/assets/2bb88b5e-9161-4800-ad3c-813782857461)


[SCCPPGHA-16]: https://sonarsource.atlassian.net/browse/SCCPPGHA-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ